### PR TITLE
Upgrade protobuf version to 3.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 MAINTAINER Steeve Morin <steeve@zen.ly>
 
 ENV GRPC_VERSION=1.0.1              \
-    PROTOBUF_VERSION=3.1.0          \
+    PROTOBUF_VERSION=3.3.0          \
     SWIFT_PROTOBUF_VERSION=0.9.24   \
     GOPATH=/go
 


### PR DESCRIPTION
This new version brings a lot of new features compared to `3.1.0`
See https://github.com/google/protobuf/releases
I tested locally and everything compiles.
We are using your image as a base for other tasks and it would be great if you accept this proposal.