### PR TITLE
Add libc-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GRPC_VERSION=1.4.0-pre1         \
     SWIFT_PROTOBUF_VERSION=0.9.24   \
     GOPATH=/go
 
-RUN apk add --no-cache build-base curl automake autoconf libtool git go zlib-dev && \
+RUN apk add --no-cache build-base curl automake autoconf libtool git go zlib-dev libc-dev && \
     curl -L https://github.com/QuentinPerez/docker-alpine-swift-protobuf/releases/download/$SWIFT_PROTOBUF_VERSION/export-lib-056f6f6.tar | tar xv -C / && \
     curl -L https://github.com/google/protobuf/archive/v${PROTOBUF_VERSION}.tar.gz | tar xvz && \
     curl -L https://raw.githubusercontent.com/QuentinPerez/docker-alpine-swift-protobuf/master/ressources/ld_library_path.patch > /ld_library_path.patch && \


### PR DESCRIPTION
After the last commit https://github.com/znly/docker-protobuf/commit/2fce12f5dd57f8efcab02aec118663b69f0ffdaf we get compiling error. It's due to the upgrade of the alpine image.

```
/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find Scrt1.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lpthread
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lssp_nonshared
collect2: error: ld returned 1 exit status
```
Adding package `libc-dev` resolves build problems.

It's a known issue that already occurred at ETSY https://github.com/etsy/hound/pull/237/commits/7fad470f9c4b9cbd642d9635bf79571abfa17b5d

For now, I added this package in my custom image however, it would be nice if you would add it directly here :)