### PR TITLE
Adds Python support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,4 +138,14 @@ RUN apk add --no-cache curl && \
         curl -L -o /protobuf/github.com/gogo/protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto && \
     apk del curl
 
-ENTRYPOINT ["/usr/bin/protoc", "-I/protobuf"]
+RUN apk add --no-cache python py2-pip python-dev gcc libc-dev g++ && \
+    pip install grpcio-tools                                      && \
+    apk del libc-dev g++ gcc python2-dev \
+            sqlite-libs readline ncurses-libs ncurses-terminfo \
+            ncurses-terminfo-base gdbm libffi expat libbz2     \
+            musl-dev mpc1 mpfr3 pkgconf libatomic libgomp isl  \
+            gmp binutils binutils-libs
+
+
+COPY "protoc-switch.sh" "/usr/local/bin/protoc-switch.sh"
+ENTRYPOINT ["/usr/local/bin/protoc-switch.sh"]

--- a/protoc-switch.sh
+++ b/protoc-switch.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+arg1=$1
+
+shift 2> /dev/null
+
+case "$arg1" in
+  protoc)
+    /usr/bin/protoc -I/protobuf $* ;;
+  python*)
+    /usr/bin/python2 $* ;;
+  bash|sh)
+    /bin/$arg1 $* ;;
+  *)
+    /usr/bin/protoc -I/protobuf $arg1 $*;;
+esac


### PR DESCRIPTION
Hello

It adds Python/gRPC support to the Docker image (cf #23).

Unfortunately, it adds 96 MB to the image size and the Docker build takes longer to compile everything.

```
$ docker images|grep /protoc
REPOSITORY                          TAG                 IMAGE ID            CREATED             SIZE
nbareil/protoc                      latest              82c95d48ede8        16 minutes ago      298MB
znly/protoc                         latest              4933f5718377        4 months ago        202MB
```

Example of usage:

```
$ ls
bar.proto
$ mkdir auto
$ docker run --rm -v $(PWD):/protobuf/foo -u `id -u`:`id -g`  znly/protoc python2 \
                -m grpc_tools.protoc -I/protobuf  --python_out=/protobuf/foo/auto \
                --grpc_python_out=/protobuf/foo/auto /protobuf/foo/bar.proto
```

Best regards