### PR TITLE
Dockerfile: Add mwitkow/go-proto-validators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN go get -u -v -ldflags '-w -s' \
         github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
         github.com/johanbrandhorst/protobuf/protoc-gen-gopherjs \
         github.com/ckaznocha/protoc-gen-lint \
+        github.com/mwitkow/go-proto-validators/protoc-gen-govalidators \
         && install -c ${GOPATH}/bin/protoc-gen* ${OUTDIR}/usr/bin/
 
 RUN mkdir -p ${GOPATH}/src/github.com/pseudomuto/protoc-gen-doc && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,8 @@ RUN apk add --no-cache curl && \
         done && \
     mkdir -p /protobuf/github.com/gogo/protobuf/gogoproto && \
         curl -L -o /protobuf/github.com/gogo/protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto && \
+    mkdir -p /protobuf/github.com/mwitkow/go-proto-validators && \
+        curl -L -o /protobuf/github.com/mwitkow/go-proto-validators/validator.proto https://raw.githubusercontent.com/mwitkow/go-proto-validators/master/validator.proto && \
     apk del curl
 
 ENTRYPOINT ["/usr/bin/protoc", "-I/protobuf"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ All inclusive protoc suite, powered by Docker and Alpine Linux.
   - github.com/gogo/protobuf/protoc-gen-gogoslick
   - github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
   - github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+  - github.com/mwitkow/go-proto-validators
 
 ## Supported languages
 - C


### PR DESCRIPTION
Add support for `--govalidators_out` option, as `--govalidators_out=gogoimport=true:.`
