### PR TITLE
chmod a+x for protoc binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,7 @@ RUN apk add --no-cache curl && \
         curl -L -o /protobuf/github.com/gogo/protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto && \
         mkdir -p /protobuf/github.com/mwitkow/go-proto-validators && \
         curl -L -o /protobuf/github.com/mwitkow/go-proto-validators/validator.proto https://raw.githubusercontent.com/mwitkow/go-proto-validators/master/validator.proto && \
-        apk del curl
+        apk del curl && \
+        chmod a+x /usr/bin/protoc
 
 ENTRYPOINT ["/usr/bin/protoc", "-I/protobuf"]


### PR DESCRIPTION
When you run current docker container output files that will be generated are owned by root. 
To omit it you can run:
```
docker run --rm -u $(id -u):$(id -g) -v $(pwd):$(pwd) -w $(pwd) znly/protoc --python_out=. -I. myfile.proto
```
but with current implementation /usr/bin/protoc will not be visible to other users that root

This issues current PR is targeting