### PR TITLE
Add ts-protoc-gen plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All inclusive protoc suite, powered by Docker and Alpine Linux.
 - Go
 - Swift 4
 - Rust
+- TypeScript
 
 ## Usage
 ```


### PR DESCRIPTION
Hi,

Thank you for your nice docker image. I added the [ts-protoc-gen](https://github.com/improbable-eng/ts-protoc-gen) plugin.

I confirmed that the command like the below works:

```sh
docker run -it -v "$(pwd)":/work -w /work znly/docker-protobuf \
                        --js_out="import_style=commonjs,binary:generated/typescript" \
                        --ts_out="service=true:generated/typescript" \
                        -I. protobuf/foo.proto
```

Could you review it? :pray:

Related Issue: https://github.com/znly/docker-protobuf/issues/56